### PR TITLE
Filename prefix is now dynamic - determined by current project

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,11 +1,11 @@
 {
-  "name": "expected_depth_v1.1.1",
-  "title": "expected_depth_v1.1.1",
+  "name": "expected_depth_v1.1.2",
+  "title": "expected_depth_v1.1.2",
   "summary": "Calculates the expected depth per gene for a whole run.",
   "tags":["Coverage"],
   "dxapi": "1.0.0",
   "properties": {
-    "githubRelease":"v1.1.1"
+    "githubRelease":"v1.1.2"
   },
   "inputSpec": [
     {

--- a/src/dnanexus_expected_depth.sh
+++ b/src/dnanexus_expected_depth.sh
@@ -49,7 +49,7 @@ main() {
     done
 
     # Get project name as prefix to the output files
-    project_name=$(dx describe project-Fjj60Qj4yBGvQXbb5Z6FXkgF --json | jq '.name' | sed 's/"//g')
+    project_name=$(dx describe $DX_PROJECT_CONTEXT_ID --json | jq '.name' | sed 's/"//g')
 
     # Run expected_depth script.
     echo "Running analysis"


### PR DESCRIPTION
Was previously hardcoded to EMEE Frankfurt, so output file was always called 
EMEE-Frankfurt.refseq_nirvana_5bp.gz
Closes #6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_expected_depth/7)
<!-- Reviewable:end -->
